### PR TITLE
Removing deprcated warnings.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -402,7 +402,7 @@ TaskBar.prototype = {
 
 		//Reset Activities Button Color if changed
 		if (this.settings.get_string("activities-button-color") !== "unset")
-			Main.panel.statusArea.activities.actor.set_style("None");
+			Main.panel.statusArea.activities.set_style("None");
 
 		//Enable Hot Corner if disabled
 		if ((!this.settings.get_boolean("hot-corner")) && (ShellVersion[1] < 26))
@@ -417,7 +417,7 @@ TaskBar.prototype = {
 
 		//Reset Application Menu Color if changed
 		if (this.settings.get_string("application-menu-color") !== "unset")
-			Main.panel.statusArea.appMenu.actor.set_style("None");
+			Main.panel.statusArea.appMenu.set_style("None");
 
 		//Show Date Menu if hidden
 		if (!this.settings.get_boolean("date-menu"))
@@ -425,7 +425,7 @@ TaskBar.prototype = {
 
 		//Reset Date Menu Color if changed
 		if (this.settings.get_string("date-menu-color") !== "unset")
-			Main.panel.statusArea.dateMenu.actor.set_style("None");
+			Main.panel.statusArea.dateMenu.set_style("None");
 
 		//Show System Menu if hidden
 		if (!this.settings.get_boolean("system-menu"))
@@ -433,7 +433,7 @@ TaskBar.prototype = {
 
 		//Reset System Menu Color if changed
 		if (this.settings.get_string("system-menu-color") !== "unset")
-			Main.panel.statusArea.aggregateMenu.actor.set_style("None");
+			Main.panel.statusArea.aggregateMenu.set_style("None");
 
 		//Show Dash if hidden
 		if (!this.settings.get_boolean("dash")) {
@@ -573,7 +573,7 @@ TaskBar.prototype = {
 			this.bottomPanelActor = null;
 		}
 		if ((this.setAnchorPoint) && (ShellVersion[1] <= 14)) {
-			Main.messageTray.actor.set_anchor_point(0, 0);
+			Main.messageTray.set_anchor_point(0, 0);
 			Main.messageTray._notificationWidget.set_anchor_point(0, 0);
 			this.setAnchorPoint = false;
 		}
@@ -588,22 +588,22 @@ TaskBar.prototype = {
 		this.cleanTasksList();
 		if (this.topPanelBackgroundColor !== 'unset') {
 			if (ShellVersion[1] <= 16) {
-				Main.panel._leftCorner.actor.show();
-				Main.panel._rightCorner.actor.show();
+				Main.panel._leftCorner.show();
+				Main.panel._rightCorner.show();
 			}
-			Main.panel._leftCorner.actor.set_style(this.originalLeftPanelCornerStyle);
-			Main.panel._rightCorner.actor.set_style(this.originalRightPanelCornerStyle);
+			Main.panel._leftCorner.set_style(this.originalLeftPanelCornerStyle);
+			Main.panel._rightCorner.set_style(this.originalRightPanelCornerStyle);
 		}
 		if ((this.topPanelBackgroundColor !== 'unset') || (this.panelSet))
-			Main.panel.actor.set_style(this.originalTopPanelStyle);
+			Main.panel.set_style(this.originalTopPanelStyle);
 		if (!this.settings.get_boolean("top-panel")) {
 			Main.layoutManager.removeChrome(Main.layoutManager.panelBox);
 			Main.layoutManager.addChrome(Main.layoutManager.panelBox, {
 				affectsStruts: true
 			});
-			Main.panel._leftCorner.actor.show();
-			Main.panel._rightCorner.actor.show();
-			Main.panel.actor.show();
+			Main.panel._leftCorner.show();
+			Main.panel._rightCorner.show();
+			Main.panel.show();
 		}
 	},
 
@@ -1311,9 +1311,9 @@ TaskBar.prototype = {
 		this.activitiesColor = this.settings.get_string("activities-button-color");
 		if (this.activitiesColor !== "unset") {
 			this.activitiesStyle = "color: " + this.activitiesColor + ";";
-			Main.panel.statusArea.activities.actor.set_style(this.activitiesStyle);
+			Main.panel.statusArea.activities.set_style(this.activitiesStyle);
 		} else
-			Main.panel.statusArea.activities.actor.set_style("None");
+			Main.panel.statusArea.activities.set_style("None");
 	},
 
 	//Top Panel
@@ -1324,9 +1324,9 @@ TaskBar.prototype = {
 			Main.layoutManager.addChrome(Main.layoutManager.panelBox, {
 				affectsStruts: true
 			});
-			Main.panel.actor.show();
-			Main.panel._leftCorner.actor.show();
-			Main.panel._rightCorner.actor.show();
+			Main.panel.show();
+			Main.panel._leftCorner.show();
+			Main.panel._rightCorner.show();
 			this.onParamChanged();
 		}
 	},
@@ -1337,9 +1337,9 @@ TaskBar.prototype = {
 			Main.layoutManager.addChrome(Main.layoutManager.panelBox, {
 				affectsStruts: false
 			});
-			Main.panel.actor.hide();
-			Main.panel._leftCorner.actor.hide();
-			Main.panel._rightCorner.actor.hide();
+			Main.panel.hide();
+			Main.panel._leftCorner.hide();
+			Main.panel._rightCorner.hide();
 		}
 	},
 
@@ -1397,9 +1397,9 @@ TaskBar.prototype = {
 		this.appMenuColor = this.settings.get_string("application-menu-color");
 		if (this.appMenuColor !== "unset") {
 			this.appMenuStyle = "color: " + this.appMenuColor + ";";
-			Main.panel.statusArea.appMenu.actor.set_style(this.appMenuStyle);
+			Main.panel.statusArea.appMenu.set_style(this.appMenuStyle);
 		} else
-			Main.panel.statusArea.appMenu.actor.set_style("None");
+			Main.panel.statusArea.appMenu.set_style("None");
 	},
 
 
@@ -1424,9 +1424,9 @@ TaskBar.prototype = {
 		this.dateMenuColor = this.settings.get_string("date-menu-color");
 		if (this.dateMenuColor !== "unset") {
 			this.dateMenuStyle = "color: " + this.dateMenuColor + ";";
-			Main.panel.statusArea.dateMenu.actor.set_style(this.dateMenuStyle);
+			Main.panel.statusArea.dateMenu.set_style(this.dateMenuStyle);
 		} else
-			Main.panel.statusArea.dateMenu.actor.set_style("None");
+			Main.panel.statusArea.dateMenu.set_style("None");
 	},
 
 	//System Menu
@@ -1450,9 +1450,9 @@ TaskBar.prototype = {
 		this.systemMenuColor = this.settings.get_string("system-menu-color");
 		if (this.systemMenuColor !== "unset") {
 			this.systemMenuStyle = "color: " + this.systemMenuColor + ";";
-			Main.panel.statusArea.aggregateMenu.actor.set_style(this.systemMenuStyle);
+			Main.panel.statusArea.aggregateMenu.set_style(this.systemMenuStyle);
 		} else
-			Main.panel.statusArea.aggregateMenu.actor.set_style("None");
+			Main.panel.statusArea.aggregateMenu.set_style("None");
 	},
 
 	//Dash
@@ -1466,7 +1466,7 @@ TaskBar.prototype = {
 
 	initDisplayDash: function() {
 		if (!this.settings.get_boolean("dash")) {
-			this.dash = Main.overview._dash.actor;
+			this.dash = Main.overview.dash;
 			this.dashHeight = this.dash.get_height();
 			this.dashWidth = this.dash.get_width();
 			this.dash.set_height(0);
@@ -1564,11 +1564,11 @@ TaskBar.prototype = {
 		this.adjustTBLabelSize = this.settings.get_int('tb-label-size');
 		this.adjustContentSize = this.settings.get_int('content-size');
 		this.panelSet = false;
-		this.originalTopPanelStyle = Main.panel.actor.get_style();
-		this.originalLeftPanelCornerStyle = Main.panel._leftCorner.actor.get_style();
-		this.originalRightPanelCornerStyle = Main.panel._rightCorner.actor.get_style();
+		this.originalTopPanelStyle = Main.panel.get_style();
+		this.originalLeftPanelCornerStyle = Main.panel._leftCorner.get_style();
+		this.originalRightPanelCornerStyle = Main.panel._rightCorner.get_style();
 		//Get Native Panel Background Color
-		let tpobc = Main.panel.actor.get_theme_node().get_background_color();
+		let tpobc = Main.panel.get_theme_node().get_background_color();
 		let topPanelOriginalBackgroundColor = 'rgba(%d, %d, %d, %d)'.format(tpobc.red, tpobc.green, tpobc.blue, tpobc.alpha);
 		this.settings.set_string("top-panel-original-background-color", topPanelOriginalBackgroundColor);
 		this.bottomPanelBackgroundColor = this.settings.get_string("bottom-panel-background-color");
@@ -1579,7 +1579,7 @@ TaskBar.prototype = {
 			//Set Font Size
 			this.panelLabelSize = (this.panelSize - 12 + this.adjustContentSize);
 			this.fontSize = 'font-size: ' + this.panelLabelSize + 'px; height: ' + this.panelSize + 'px;';
-			Main.panel.actor.set_style(this.fontSize);
+			Main.panel.set_style(this.fontSize);
 			this.panelSet = true;
 		}
 		this.topPanelBackgroundColor = this.settings.get_string("top-panel-background-color");
@@ -1587,17 +1587,17 @@ TaskBar.prototype = {
 			this.topPanelBackgroundStyle = "background-color: " + this.topPanelBackgroundColor + ";";
 			this.panelLabelSize = (this.panelSize - 12 + this.adjustContentSize);
 			this.fontSize = 'font-size: ' + this.panelLabelSize + 'px; height: ' + this.panelSize + 'px;';
-			Main.panel.actor.set_style(this.fontSize + ' ' + this.topPanelBackgroundStyle);
+			Main.panel.set_style(this.fontSize + ' ' + this.topPanelBackgroundStyle);
 			if ((this.settings.get_boolean("top-panel-background-alpha")) && (ShellVersion[1] <= 16)) {
-				Main.panel._leftCorner.actor.hide();
-				Main.panel._rightCorner.actor.hide();
+				Main.panel._leftCorner.hide();
+				Main.panel._rightCorner.hide();
 			} else {
 				if (ShellVersion[1] <= 16) {
-					Main.panel._leftCorner.actor.show();
-					Main.panel._rightCorner.actor.show();
+					Main.panel._leftCorner.show();
+					Main.panel._rightCorner.show();
 				}
-				Main.panel._leftCorner.actor.set_style('-panel-corner-background-color: ' + this.topPanelBackgroundColor + ';');
-				Main.panel._rightCorner.actor.set_style('-panel-corner-background-color: ' + this.topPanelBackgroundColor + ';');
+				Main.panel._leftCorner.set_style('-panel-corner-background-color: ' + this.topPanelBackgroundColor + ';');
+				Main.panel._rightCorner.set_style('-panel-corner-background-color: ' + this.topPanelBackgroundColor + ';');
 			}
 			this.panelSet = true;
 		}
@@ -1658,11 +1658,11 @@ TaskBar.prototype = {
 			Main.messageTray._notificationWidget.set_anchor_point(0, this.height);
 			this.setAnchorPoint = true;
 			this.messageTrayShowingId = Main.messageTray.connect('showing', Lang.bind(this, function() {
-				Main.messageTray.actor.set_anchor_point(0, this.height);
+				Main.messageTray.set_anchor_point(0, this.height);
 				this.setAnchorPoint = true;
 			}));
 			this.messageTrayHidingId = Main.messageTray.connect('hiding', Lang.bind(this, function() {
-				Main.messageTray.actor.set_anchor_point(0, 0);
+				Main.messageTray.set_anchor_point(0, 0);
 				this.setAnchorPoint = true;
 			}));
 		}
@@ -1946,9 +1946,9 @@ TaskBar.prototype = {
 	        }
 	    }
 
-	    this.taskMenu.actor.hide();
+	    this.taskMenu.hide();
 	    taskMenuManager.addMenu(this.taskMenu);
-	    Main.uiGroup.add_actor(this.taskMenu.actor);
+	    Main.uiGroup.add_actor(this.taskMenu);
 	    this.taskMenuUp = true;
 	    this.hidePreview();
 	    this.taskMenu.open();


### PR DESCRIPTION
I had a bug with this as a "Main.overview._dash" message.
In fact "Main.overview._dash" is deprecated and replaced by 
"Main.overview.dash". (see #14)
I take the opportunity to remove the "actors" who are also depreciated.